### PR TITLE
HW1 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # 64drive USB tool for Linux
 
 A tool to upload to/from 64drive development cartridge over USB.
-
-Only tested with HW2.

--- a/src/main.c
+++ b/src/main.c
@@ -401,6 +401,7 @@ int device_open(sixtyfourDrive *device) {
     } devices[] = {
         {0x0403, 0x6014, 2, "64drive USB device"},
         {0x0403, 0x6010, 1, "64drive USB device A"},
+        {0x0403, 0x6010, 1, "64drive USB device"},
         {0, 0, 0, NULL}
     };
 


### PR DESCRIPTION
This tool was unable to work with my 64drive HW1. I investigated, and with a small patch, I was able to get it to work.
This tool is looking for HW1 devices with the description "64drive USB device A". However, my HW1 64drive doesn't have the " A" at the end. I'm not sure what that's for.
This PR allows the use of HW1 devices with or without the " A" suffix. It doesn't hurt to support both.
Future work would verify that " A"-suffixed HW1s really do exist, and that this tool really does work with them.